### PR TITLE
Fix missing config file access

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -8,7 +8,7 @@ const LanguageManager = require('../utils/language');
 
 class DiscordSelfbotCLI {
     constructor() {
-        this.configFile = path.join(__dirname, '../../config/ihannsy.json');
+        this.configFile = path.join(process.cwd(), 'config/ihannsy.json');
         this.updateManager = new RepositoryUpdateManager();
         this.languageManager = new LanguageManager();
         this.loadLanguageSettings();

--- a/src/config/manager.js
+++ b/src/config/manager.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 class ConfigManager {
     constructor() {
-        this.configFile = path.join(__dirname, '../../config/ihannsy.json');
+        this.configFile = path.join(process.cwd(), 'config/ihannsy.json');
         this.config = this.loadConfig();
     }
 


### PR DESCRIPTION
Update config file path resolution to use `process.cwd()` to fix `ENOENT` errors when accessing `ihannsy.json`.

The previous path construction using `__dirname` incorrectly resolved the config file path relative to the source directory, leading to "file not found" errors when the application tried to save accounts or update language settings. By switching to `process.cwd()`, the config file is now correctly located in the project's root `config/` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-d365c494-7df4-4b36-a291-71bffd2f2b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d365c494-7df4-4b36-a291-71bffd2f2b13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

